### PR TITLE
add orca recipes

### DIFF
--- a/omdata/orca/calc.py
+++ b/omdata/orca/calc.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from shutil import which
+
+from ase.calculators.orca import ORCA, OrcaProfile
+from pydantic import Field
+from sella import Sella
+
+ORCA_FUNCTIONAL = "wB97M-V"
+ORCA_BASIS = "def2-TZVPD"
+ORCA_SIMPLE_INPUT = [
+    "EnGrad",
+    "RIJCOSX",
+    "def2/J",
+    "NoUseSym",
+    "DIIS",
+    "NOSOSCF",
+    "NormalConv",
+    "DEFGRID3",
+]
+ORCA_SIMPLE_INPUT_QUACC_IGNORE = [
+    "#slowconv",
+]
+ORCA_BLOCKS = ["%scf Convergence Tight maxiter 500 end"]
+ORCA_ASE_SIMPLE_INPUT = " ".join([ORCA_FUNCTIONAL] + [ORCA_BASIS] + ORCA_SIMPLE_INPUT)
+OPT_PARAMETERS = {
+    "optimizer": Sella,
+    "store_intermediate_files": True,
+    "fmax": 0.01,
+    "max_steps": 1000,
+}
+
+
+def write_orca_inputs(
+    atoms,
+    output_directory,
+    charge=0,
+    mult=1,
+    orcasimpleinput=ORCA_ASE_SIMPLE_INPUT,
+    orcablocks=" ".join(ORCA_BLOCKS),
+):
+
+    MyOrcaProfile = OrcaProfile([Field(Path(which("orca") or "orca")).default])
+    calc = ORCA(
+        charge=charge,
+        mult=mult,
+        profile=MyOrcaProfile,
+        orcasimpleinput=orcasimpleinput,
+        orcablocks=orcablocks,
+        directory=output_directory,
+    )
+    calc.write_inputfiles(atoms, ["energy", "forces"])

--- a/omdata/orca/calc.py
+++ b/omdata/orca/calc.py
@@ -15,11 +15,9 @@ ORCA_SIMPLE_INPUT = [
     "DIIS",
     "NOSOSCF",
     "NormalConv",
-    "DEFGRID3",
+    "DEFGRID2",
 ]
-ORCA_SIMPLE_INPUT_QUACC_IGNORE = [
-    "#slowconv",
-]
+ORCA_SIMPLE_INPUT_QUACC_IGNORE = []
 ORCA_BLOCKS = ["%scf Convergence Tight maxiter 500 end"]
 ORCA_ASE_SIMPLE_INPUT = " ".join([ORCA_FUNCTIONAL] + [ORCA_BASIS] + ORCA_SIMPLE_INPUT)
 OPT_PARAMETERS = {
@@ -43,7 +41,7 @@ def write_orca_inputs(
     system. Primarily used for debugging.
     """
 
-    MyOrcaProfile = OrcaProfile([Field(Path(which("orca") or "orca")).default])
+    MyOrcaProfile = OrcaProfile([str(Field(Path(which("orca") or "orca")).default)])
     calc = ORCA(
         charge=charge,
         mult=mult,

--- a/omdata/orca/calc.py
+++ b/omdata/orca/calc.py
@@ -38,6 +38,10 @@ def write_orca_inputs(
     orcasimpleinput=ORCA_ASE_SIMPLE_INPUT,
     orcablocks=" ".join(ORCA_BLOCKS),
 ):
+    """
+    One-off method to be used if you wanted to write inputs for an arbitrary
+    system. Primarily used for debugging.
+    """
 
     MyOrcaProfile = OrcaProfile([Field(Path(which("orca") or "orca")).default])
     calc = ORCA(

--- a/omdata/orca/calc.py
+++ b/omdata/orca/calc.py
@@ -24,7 +24,7 @@ ORCA_BLOCKS = ["%scf Convergence Tight maxiter 500 end"]
 ORCA_ASE_SIMPLE_INPUT = " ".join([ORCA_FUNCTIONAL] + [ORCA_BASIS] + ORCA_SIMPLE_INPUT)
 OPT_PARAMETERS = {
     "optimizer": Sella,
-    "store_intermediate_files": True,
+    "store_intermediate_results": True,
     "fmax": 0.01,
     "max_steps": 1000,
 }

--- a/omdata/orca/recipes.py
+++ b/omdata/orca/recipes.py
@@ -1,6 +1,5 @@
 import os
 import pickle
-import shutil
 
 from quacc.recipes.orca.core import ase_relax_job, static_job
 from quacc.wflow_tools.customizers import strip_decorator
@@ -24,7 +23,7 @@ def single_point_calculation(
     orcasimpleinput=ORCA_SIMPLE_INPUT,
     orcablocks=ORCA_BLOCKS,
     nprocs=12,
-    outputdir=None,
+    outputdir=os.getcwd(),
 ):
     """
     Wrapper around QUACC's static job to standardize single-point calculations.
@@ -53,6 +52,9 @@ def single_point_calculation(
     outputdir: str
         Directory to move results to upon completion
     """
+    from quacc import SETTINGS
+
+    SETTINGS.RESULTS_DIR = outputdir
 
     o = strip_decorator(static_job)(
         atoms,
@@ -66,8 +68,6 @@ def single_point_calculation(
     )
     # TODO: how we want to handle what results to save out and where to store
     # them.
-    os.makedirs(outputdir, exist_ok=True)
-    shutil.move(o["dir_name"], outputdir)
     with open(os.path.join(outputdir, "quacc_results.pkl"), "wb") as f:
         pickle.dump(o, f)
 
@@ -82,7 +82,7 @@ def ase_relaxation(
     orcablocks=ORCA_BLOCKS,
     nprocs=12,
     opt_params=OPT_PARAMETERS,
-    outputdir=None,
+    outputdir=os.getcwd(),
 ):
     """
     Wrapper around QUACC's ase_relax_job to standardize geometry optimizations.
@@ -113,6 +113,10 @@ def ase_relaxation(
     outputdir: str
         Directory to move results to upon completion
     """
+    from quacc import SETTINGS
+
+    SETTINGS.RESULTS_DIR = outputdir
+
     o = strip_decorator(ase_relax_job)(
         atoms,
         charge=charge,
@@ -124,9 +128,6 @@ def ase_relaxation(
         opt_params=opt_params,
         nprocs=nprocs,
     )
-    # TODO: how we want to handle what results to save out and where to store
-    # them.
-    os.makedirs(outputdir, exist_ok=True)
-    shutil.move(o["dir_name"], outputdir)
+    # TODO: how we want to handle what results to save out and where to store them.
     with open(os.path.join(outputdir, "quacc_results.pkl"), "wb") as f:
         pickle.dump(o, f)

--- a/omdata/orca/recipes.py
+++ b/omdata/orca/recipes.py
@@ -1,0 +1,132 @@
+import os
+import pickle
+import shutil
+
+from quacc.recipes.orca.core import ase_relax_job, static_job
+from quacc.wflow_tools.customizers import strip_decorator
+
+from omdata.orca.calc import (
+    OPT_PARAMETERS,
+    ORCA_BASIS,
+    ORCA_BLOCKS,
+    ORCA_FUNCTIONAL,
+    ORCA_SIMPLE_INPUT,
+    ORCA_SIMPLE_INPUT_QUACC_IGNORE,
+)
+
+
+def single_point_calculation(
+    atoms,
+    charge,
+    spin_multiplicity,
+    xc=ORCA_FUNCTIONAL,
+    basis=ORCA_BASIS,
+    orcasimpleinput=ORCA_SIMPLE_INPUT,
+    orcablocks=ORCA_BLOCKS,
+    nprocs=12,
+    outputdir=None,
+):
+    """
+    Wrapper around QUACC's static job to standardize single-point calculations.
+    See github.com/Quantum-Accelerators/quacc/blob/main/src/quacc/recipes/orca/core.py#L22
+    for more details.
+
+    Arguments
+    ---------
+
+    atoms: Atoms
+        Atoms object
+    charge: int
+        Charge of system
+    spin_multiplicity: int
+        Multiplicity of the system
+    xc: str
+        Exchange-correlaction functional
+    basis: str
+        Basis set
+    orcasimpleinput: list
+        List of `orcasimpleinput` settings for the calculator
+    orcablocks: list
+        List of `orcablocks` swaps for the calculator
+    nprocs: int
+        Number of processes to parallelize across
+    outputdir: str
+        Directory to move results to upon completion
+    """
+
+    o = strip_decorator(static_job)(
+        atoms,
+        charge=charge,
+        spin_multiplicity=spin_multiplicity,
+        xc=xc,
+        basis=basis,
+        orcasimpleinput=orcasimpleinput + ORCA_SIMPLE_INPUT_QUACC_IGNORE,
+        orcablocks=orcablocks,
+        nprocs=nprocs,
+    )
+    # TODO: how we want to handle what results to save out and where to store
+    # them.
+    os.makedirs(outputdir, exist_ok=True)
+    shutil.move(o["dir_name"], outputdir)
+    with open(os.path.join(outputdir, "quacc_results.pkl"), "wb") as f:
+        pickle.dump(o, f)
+
+
+def ase_relaxation(
+    atoms,
+    charge,
+    spin_multiplicity,
+    xc=ORCA_FUNCTIONAL,
+    basis=ORCA_BASIS,
+    orcasimpleinput=ORCA_SIMPLE_INPUT,
+    orcablocks=ORCA_BLOCKS,
+    nprocs=12,
+    opt_params=OPT_PARAMETERS,
+    outputdir=None,
+):
+    """
+    Wrapper around QUACC's ase_relax_job to standardize geometry optimizations.
+    See github.com/Quantum-Accelerators/quacc/blob/main/src/quacc/recipes/orca/core.py#L22
+    for more details.
+
+    Arguments
+    ---------
+
+    atoms: Atoms
+        Atoms object
+    charge: int
+        Charge of system
+    spin_multiplicity: int
+        Multiplicity of the system
+    xc: str
+        Exchange-correlaction functional
+    basis: str
+        Basis set
+    orcasimpleinput: list
+        List of `orcasimpleinput` settings for the calculator
+    orcablocks: list
+        List of `orcablocks` swaps for the calculator
+    nprocs: int
+        Number of processes to parallelize across
+    opt_params: dict
+        Dictionary of optimizer parameters
+    outputdir: str
+        Directory to move results to upon completion
+    """
+    o = strip_decorator(ase_relax_job)(
+        atoms,
+        charge=charge,
+        spin_multiplicity=spin_multiplicity,
+        xc=xc,
+        basis=basis,
+        orcasimpleinput=orcasimpleinput + ORCA_SIMPLE_INPUT_QUACC_IGNORE,
+        orcablocks=orcablocks,
+        opt_params=opt_params,
+        nprocs=nprocs,
+    )
+    # TODO: how we want to handle what results to save out and where to store
+    # them.
+    os.makedirs(outputdir, exist_ok=True)
+    shutil.move(o["dir_name"], outputdir)
+    with open(os.path.join(outputdir, "quacc_results.pkl"), "wb") as f:
+        pickle.dump(o, f)

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,14 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name="omdata",
     version="0.1.0",
     description="Code for generating OMOL input configurations",
     url="http://github.com/Open-Catalyst-Project/om-data",
-    packages=["ase", "quacc[sella]>=0.7.1"],
+    packages=find_packages(),
+    install_requires=["ase", "quacc[sella]>=0.7.2"],
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from setuptools import find_packages, setup
+
+setup(
+    name="omdata",
+    version="0.1.0",
+    description="Code for generating OMOL input configurations",
+    url="http://github.com/Open-Catalyst-Project/om-data",
+    packages=find_packages(),
+    include_package_data=True,
+)

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,13 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 setup(
     name="omdata",
     version="0.1.0",
     description="Code for generating OMOL input configurations",
     url="http://github.com/Open-Catalyst-Project/om-data",
-    packages=find_packages(),
+    packages=["ase", "quacc[sella]>=0.7.1"],
     include_package_data=True,
 )


### PR DESCRIPTION
To standardize the DFT settings used in the dataset, add sp/opt recipe wrappers to be used with quacc. 