### PR TITLE
scripts for sampling GEOM dataset

### DIFF
--- a/biomolecules/geom/sample_geom_drugs.py
+++ b/biomolecules/geom/sample_geom_drugs.py
@@ -1,0 +1,93 @@
+import os
+import json
+import pickle
+import random
+import argparse
+import tqdm
+
+
+def write_pickle(data, path):
+    with open(path, "wb") as f:
+        pickle.dump(data, f, pickle.HIGHEST_PROTOCOL)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--base_path",
+        type=str,
+        required=True,
+        help="Path to where you untarred the rdkit folder i.e. path/to/rdkit_folder",
+    )
+    parser.add_argument(
+        "--out_path", type=str, required=True, help="Path to the output directory"
+    )
+
+    return parser.parse_args()
+
+
+def main():
+
+    args = parse_args()
+
+    # rdkit folder downloaded 2024-03-01
+    base_path = args.base_path
+    out_path = args.out_path
+    drugs_file = os.path.join(base_path, "summary_drugs.json")
+
+    with open(drugs_file, "r") as f:
+        drugs_summ = json.load(f)
+
+    # set random seed
+    random.seed(42)
+
+    train_id_list = []
+    val_id_list = []
+    id_mol_dict = {}
+    missing_drugs = []
+
+    for drug in tqdm.tqdm(drugs_summ.keys()):
+        # not all drugs have necessary keys
+        try:
+            charge = drugs_summ[drug]["charge"]
+            pickle_path = drugs_summ[drug]["pickle_path"]
+        except KeyError:
+            missing_drugs.append(drug)
+            continue
+        pp = os.path.join(base_path, pickle_path)
+        with open(pp, "rb") as f:
+            mol_dict = pickle.load(f)
+        rand = random.random()
+        # generate train ids with 85% probability - ~5% charged
+        if charge == 0 and rand > 0.15:
+            for i, c in enumerate(mol_dict["conformers"]):
+                train_id_list.append(c["geom_id"])
+                id_mol_dict[c["geom_id"]] = {
+                    "pickle_path": drugs_summ[drug]["pickle_path"],
+                    "conf_idx": i,
+                    "charge": charge,
+                    "molecule": drug,
+                }
+        # if charge != 0 or rand =< 0.15:
+        else:
+            for i, c in enumerate(mol_dict["conformers"]):
+                val_id_list.append(c["geom_id"])
+                id_mol_dict[c["geom_id"]] = {
+                    "pickle_path": drugs_summ[drug]["pickle_path"],
+                    "conf_idx": i,
+                    "charge": charge,
+                    "molecule": drug,
+                }
+    # shuffle train list
+    for i in range(3):
+        random.shuffle(train_id_list)
+
+    # write out train/val ids, id_mol_dict, and missing drugs
+    write_pickle(train_id_list, os.path.join(out_path, "train_ids.pkl"))
+    write_pickle(val_id_list, os.path.join(out_path, "val_ids.pkl"))
+    write_pickle(id_mol_dict, os.path.join(out_path, "id_mol_dict.pkl"))
+    write_pickle(missing_drugs, os.path.join(out_path, "missing_drugs.pkl"))
+
+
+if __name__ == "__main__":
+    main()

--- a/biomolecules/geom/sample_geom_drugs.py
+++ b/biomolecules/geom/sample_geom_drugs.py
@@ -46,7 +46,7 @@ def main():
     id_mol_dict = {}
     missing_drugs = []
 
-    for drug in tqdm.tqdm(list(drugs_summ.keys())[:1000]):
+    for drug in tqdm.tqdm(drugs_summ.keys()):
         # not all drugs have necessary keys
         try:
             charge = drugs_summ[drug]["charge"]
@@ -67,10 +67,10 @@ def main():
                 "molecule": drug,
             }
             if charge == 0 and rand > 0.15:
-               train_id_list.append(c["geom_id"])
+                train_id_list.append(c["geom_id"])
             # if charge != 0 or rand =< 0.15:
             else:
-               val_id_list.append(c["geom_id"])
+                val_id_list.append(c["geom_id"])
     # shuffle train list
     for i in range(3):
         random.shuffle(train_id_list)

--- a/biomolecules/geom/sample_geom_drugs.py
+++ b/biomolecules/geom/sample_geom_drugs.py
@@ -59,25 +59,18 @@ def main():
             mol_dict = pickle.load(f)
         rand = random.random()
         # generate train ids with 85% probability - ~5% charged
-        if charge == 0 and rand > 0.15:
-            for i, c in enumerate(mol_dict["conformers"]):
-                train_id_list.append(c["geom_id"])
-                id_mol_dict[c["geom_id"]] = {
-                    "pickle_path": drugs_summ[drug]["pickle_path"],
-                    "conf_idx": i,
-                    "charge": charge,
-                    "molecule": drug,
-                }
-        # if charge != 0 or rand =< 0.15:
-        else:
-            for i, c in enumerate(mol_dict["conformers"]):
-                val_id_list.append(c["geom_id"])
-                id_mol_dict[c["geom_id"]] = {
-                    "pickle_path": drugs_summ[drug]["pickle_path"],
-                    "conf_idx": i,
-                    "charge": charge,
-                    "molecule": drug,
-                }
+        for i, c in enumerate(mol_dict["conformers"]):
+            id_mol_dict[c["geom_id"]] = {
+                "pickle_path": pickle_path,
+                "conf_idx": i,
+                "charge": charge,
+                "molecule": drug,
+            }
+          if charge == 0 and rand > 0.15:
+               train_id_list.append(c["geom_id"])
+            # if charge != 0 or rand =< 0.15:
+            else:
+               val_id_list.append(c["geom_id"])
     # shuffle train list
     for i in range(3):
         random.shuffle(train_id_list)

--- a/biomolecules/geom/sample_geom_drugs.py
+++ b/biomolecules/geom/sample_geom_drugs.py
@@ -46,7 +46,7 @@ def main():
     id_mol_dict = {}
     missing_drugs = []
 
-    for drug in tqdm.tqdm(drugs_summ.keys()):
+    for drug in tqdm.tqdm(list(drugs_summ.keys())[:1000]):
         # not all drugs have necessary keys
         try:
             charge = drugs_summ[drug]["charge"]
@@ -66,7 +66,7 @@ def main():
                 "charge": charge,
                 "molecule": drug,
             }
-          if charge == 0 and rand > 0.15:
+            if charge == 0 and rand > 0.15:
                train_id_list.append(c["geom_id"])
             # if charge != 0 or rand =< 0.15:
             else:

--- a/biomolecules/geom/sample_geom_drugs.py
+++ b/biomolecules/geom/sample_geom_drugs.py
@@ -59,18 +59,26 @@ def main():
             mol_dict = pickle.load(f)
         rand = random.random()
         # generate train ids with 85% probability - ~5% charged
-        for i, c in enumerate(mol_dict["conformers"]):
-            id_mol_dict[c["geom_id"]] = {
-                "pickle_path": pickle_path,
-                "conf_idx": i,
-                "charge": charge,
-                "molecule": drug,
-            }
-            if charge == 0 and rand > 0.15:
+        # sampling happens at the molecule level
+        if charge == 0 and rand > 0.15:
+            for i, c in enumerate(mol_dict["conformers"]):
                 train_id_list.append(c["geom_id"])
-            # if charge != 0 or rand =< 0.15:
-            else:
+                id_mol_dict[c["geom_id"]] = {
+                    "pickle_path": drugs_summ[drug]["pickle_path"],
+                    "conf_idx": i,
+                    "charge": charge,
+                    "molecule": drug,
+                }
+        # if charge != 0 or rand =< 0.15:
+        else:
+            for i, c in enumerate(mol_dict["conformers"]):
                 val_id_list.append(c["geom_id"])
+                id_mol_dict[c["geom_id"]] = {
+                    "pickle_path": drugs_summ[drug]["pickle_path"],
+                    "conf_idx": i,
+                    "charge": charge,
+                    "molecule": drug,
+                }
     # shuffle train list
     for i in range(3):
         random.shuffle(train_id_list)

--- a/biomolecules/geom/write_geom_drugs_structures.py
+++ b/biomolecules/geom/write_geom_drugs_structures.py
@@ -12,7 +12,7 @@ def parse_args():
         "--base_path",
         type=str,
         required=True,
-        help="Path to where you untarred the rdkit folder i.e. path/to/rdkit_folder",
+        help="Path to where you untarred the rdkit folder id.e. path/to/rdkit_folder",
     )
     parser.add_argument(
         "--parent_path",
@@ -67,8 +67,8 @@ def main():
     with open(idmol_path, "rb") as f:
         idmol = pickle.load(f)
 
-    for i in tqdm.tqdm(geom_ids[start_idx:stop_idx]):
-        geom_id = str(i)
+    for id in tqdm.tqdm(geom_ids[start_idx:stop_idx]):
+        geom_id = str(id)
         outdir = os.path.join(parent_path, geom_id)
         if os.path.exists(outdir):
             print(f"Directory {outdir} already exists, skipping")
@@ -76,14 +76,15 @@ def main():
         # make the directory
         os.mkdir(outdir)
         # load pickle file to get the molecule
-        pp = os.path.join(base_path, idmol[i]["pickle_path"])
+        pp = os.path.join(base_path, idmol[id]["pickle_path"])
         with open(pp, "rb") as f:
             mol_dict = pickle.load(f)
-        # get charge and conformer index
-        charge = idmol[i]["charge"]
-        conf_idx = idmol[i]["conf_idx"]
-        # multiplicity is always 1
-        f_name = os.path.join(outdir, f"structure_{charge}_1.xyz")
+        # get charge, multiplicity, and conformer index
+        charge = idmol[id]["charge"]
+        # defaults to 1 if not explicitly set
+        multiplicity = idmol[id].get("multiplicity", 1)
+        conf_idx = idmol[id]["conf_idx"]
+        f_name = os.path.join(outdir, f"structure_{charge}_{multiplicity}.xyz")
         # write xyz file
         MolToXYZFile(mol_dict["conformers"][conf_idx]["rd_mol"], f_name)
 

--- a/biomolecules/geom/write_geom_drugs_structures.py
+++ b/biomolecules/geom/write_geom_drugs_structures.py
@@ -1,0 +1,92 @@
+import os
+import pickle
+import argparse
+import tqdm
+
+from rdkit.Chem.rdmolfiles import MolToXYZFile
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--base_path",
+        type=str,
+        required=True,
+        help="Path to where you untarred the rdkit folder i.e. path/to/rdkit_folder",
+    )
+    parser.add_argument(
+        "--parent_path",
+        type=str,
+        required=True,
+        help="Path to the parent directory where structures will be written",
+    )
+    parser.add_argument(
+        "--geom_ids_path",
+        type=str,
+        required=True,
+        help="Path to geom ids pkl to write structures for",
+    )
+    parser.add_argument(
+        "--idmol_path",
+        type=str,
+        required=True,
+        help="Path to id_mol_dict.pkl",
+    )
+    parser.add_argument(
+        "--start_idx",
+        type=int,
+        required=True,
+        help="Index in split ids to start writting files",
+    )
+    parser.add_argument(
+        "--stop_idx",
+        type=int,
+        required=True,
+        help="Index in split ids to stop writting files",
+    )
+
+    return parser.parse_args()
+
+
+def main():
+
+    args = parse_args()
+
+    # rdkit folder downloaded 2024-03-01
+    base_path = args.base_path
+    parent_path = args.parent_path
+    geom_ids_path = args.geom_ids_path
+    idmol_path = args.idmol_path
+    start_idx = args.start_idx
+    stop_idx = args.stop_idx
+
+    # read split ids
+    with open(geom_ids_path, "rb") as f:
+        geom_ids = pickle.load(f)
+
+    with open(idmol_path, "rb") as f:
+        idmol = pickle.load(f)
+
+    for i in tqdm.tqdm(geom_ids[start_idx:stop_idx]):
+        geom_id = str(i)
+        outdir = os.path.join(parent_path, geom_id)
+        if os.path.exists(outdir):
+            print(f"Directory {outdir} already exists, skipping")
+            continue
+        # make the directory
+        os.mkdir(outdir)
+        # load pickle file to get the molecule
+        pp = os.path.join(base_path, idmol[i]["pickle_path"])
+        with open(pp, "rb") as f:
+            mol_dict = pickle.load(f)
+        # get charge and conformer index
+        charge = idmol[i]["charge"]
+        conf_idx = idmol[i]["conf_idx"]
+        # multiplicity is always 1
+        f_name = os.path.join(outdir, f"structure_{charge}_1.xyz")
+        # write xyz file
+        MolToXYZFile(mol_dict["conformers"][conf_idx]["rd_mol"], f_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/biomolecules/geom/write_geom_drugs_structures.py
+++ b/biomolecules/geom/write_geom_drugs_structures.py
@@ -67,15 +67,11 @@ def main():
     with open(idmol_path, "rb") as f:
         idmol = pickle.load(f)
 
+    outdir = os.path.join(parent_path, f"{start_idx}_{stop_idx}_geom_structures")
+    assert not os.path.exists(outdir), f"Directory {outdir} already exists"
+    os.makedirs(outdir)
+
     for id in tqdm.tqdm(geom_ids[start_idx:stop_idx]):
-        geom_id = str(id)
-        outdir = os.path.join(parent_path, geom_id)
-        if os.path.exists(outdir):
-            print(f"Directory {outdir} already exists, skipping")
-            continue
-        # make the directory
-        os.mkdir(outdir)
-        # load pickle file to get the molecule
         pp = os.path.join(base_path, idmol[id]["pickle_path"])
         with open(pp, "rb") as f:
             mol_dict = pickle.load(f)
@@ -84,7 +80,7 @@ def main():
         # defaults to 1 if not explicitly set
         multiplicity = idmol[id].get("multiplicity", 1)
         conf_idx = idmol[id]["conf_idx"]
-        f_name = os.path.join(outdir, f"structure_{charge}_{multiplicity}.xyz")
+        f_name = os.path.join(outdir, f"{id}_{charge}_{multiplicity}.xyz")
         # write xyz file
         MolToXYZFile(mol_dict["conformers"][conf_idx]["rd_mol"], f_name)
 


### PR DESCRIPTION
These two scripts allow us to sample GEOM drugs (we are ignoring the qm9 split) and write the xyz structures. 

sample_geom_drugs.py is the sampling script: it looks through the GEOM drugs metadata file and creates train and val ids (using geom ids, unique to a conformer). The train ids get shuffled because we want to randomly sample across conformers. In addition to the ids pickles, an id_mol_dict is written which maps geom_id to the molecule, charge, conformer index, and pickle path where the rdkit mol object is stored. 

write_geom_drugs_structures.py takes in the geom_ids list and writes the xyz structures for the specified start and stop indices, which enables writing xyz files of a subset of the geom_ids list. 