### PR TITLE
explicitly define sella kwargs

### DIFF
--- a/omdata/orca/calc.py
+++ b/omdata/orca/calc.py
@@ -18,7 +18,7 @@ ORCA_SIMPLE_INPUT = [
 ]
 ORCA_SIMPLE_INPUT_QUACC_IGNORE = []
 ORCA_BLOCKS = [
-    "%scf Convergence Tight maxiter 500 end",
+    "%scf Convergence Tight maxiter 300 end",
     "%elprop Dipole true Quadrupole true end",
 ]
 ORCA_ASE_SIMPLE_INPUT = " ".join([ORCA_FUNCTIONAL] + [ORCA_BASIS] + ORCA_SIMPLE_INPUT)
@@ -26,7 +26,7 @@ OPT_PARAMETERS = {
     "optimizer": Sella,
     "store_intermediate_results": True,
     "fmax": 0.05,
-    "max_steps": 1000,
+    "max_steps": 100,
     "optimizer_kwargs": {
         "order": 0,
         "internal": True,


### PR DESCRIPTION
These are consistent with what quacc is defining - https://github.com/Quantum-Accelerators/quacc/blob/487376b5450eed2c720fb6ab76bcdbb11b7921d7/src/quacc/runners/ase.py#L315-L319 But we make it explicit in our configs.