### PR TITLE
Add printing of Reduced Mulliken and Lowdin populations for each orbital

### DIFF
--- a/omdata/orca/calc.py
+++ b/omdata/orca/calc.py
@@ -21,6 +21,7 @@ ORCA_BLOCKS = [
     "%scf Convergence Tight maxiter 300 end",
     "%elprop Dipole true Quadrupole true end",
     '%nbo NBOKEYLIST = "$NBO NPA NBO E2PERT 0.1 $END" end',
+    '%output Print[P_ReducedOrbPopMO_L] 1 Print[P_ReducedOrbPopMO_M] 1 Print[P_BondOrder_L] 1 Print[P_BondOrder_M] 1 end',
 ]
 ORCA_ASE_SIMPLE_INPUT = " ".join([ORCA_FUNCTIONAL] + [ORCA_BASIS] + ORCA_SIMPLE_INPUT)
 OPT_PARAMETERS = {


### PR DESCRIPTION
Also added Lowdin and Mulliken bond orders since they were the only population feature missing from the NormalPrint level.