### PR TITLE
Add a function to estimate (an upper-bound) to the memory needed for an Orca job (i.e. %maxcore)

### DIFF
--- a/omdata/orca/calc.py
+++ b/omdata/orca/calc.py
@@ -12,6 +12,94 @@ ECP_SIZE = {
     **{i: 28 for i in range(58, 72)},
     **{i: 60 for i in range(72, 87)},
 }
+BASIS_DICT = {
+    "H": 9,
+    "He": 9,
+    "Li": 17,
+    "Be": 22,
+    "B": 37,
+    "C": 37,
+    "N": 37,
+    "O": 40,
+    "F": 40,
+    "Ne": 40,
+    "Na": 35,
+    "Mg": 35,
+    "Al": 43,
+    "Si": 43,
+    "P": 43,
+    "S": 46,
+    "Cl": 46,
+    "Ar": 46,
+    "K": 36,
+    "Ca": 36,
+    "Sc": 48,
+    "Ti": 48,
+    "V": 48,
+    "Cr": 48,
+    "Mn": 48,
+    "Fe": 48,
+    "Co": 48,
+    "Ni": 48,
+    "Cu": 48,
+    "Zn": 51,
+    "Ga": 54,
+    "Ge": 54,
+    "As": 54,
+    "Se": 57,
+    "Br": 57,
+    "Kr": 57,
+    "Rb": 33,
+    "Sr": 33,
+    "Y": 40,
+    "Zr": 40,
+    "Nb": 40,
+    "Mo": 40,
+    "Tc": 40,
+    "Ru": 40,
+    "Rh": 40,
+    "Pd": 40,
+    "Ag": 40,
+    "Cd": 40,
+    "In": 56,
+    "Sn": 56,
+    "Sb": 56,
+    "Te": 59,
+    "I": 59,
+    "Xe": 59,
+    "Cs": 32,
+    "Ba": 40,
+    "La": 43,
+    "Ce": 105,
+    "Pr": 105,
+    "Nd": 98,
+    "Pm": 98,
+    "Sm": 98,
+    "Eu": 93,
+    "Gd": 98,
+    "Tb": 98,
+    "Dy": 98,
+    "Ho": 98,
+    "Er": 101,
+    "Tm": 101,
+    "Yb": 96,
+    "Lu": 96,
+    "Hf": 43,
+    "Ta": 43,
+    "W": 43,
+    "Re": 43,
+    "Os": 43,
+    "Ir": 43,
+    "Pt": 43,
+    "Au": 43,
+    "Hg": 46,
+    "Tl": 56,
+    "Pb": 56,
+    "Bi": 56,
+    "Po": 59,
+    "At": 59,
+    "Rn": 59,
+}
 
 ORCA_FUNCTIONAL = "wB97M-V"
 ORCA_BASIS = "def2-TZVPD"
@@ -73,6 +161,36 @@ def get_symm_break_block(atoms: Atoms, charge: int) -> str:
     n_electrons -= ecp_electrons
     lumo = n_electrons // 2
     return f"%scf rotate {{{lumo-1}, {lumo}, 20, 1, 1}} end end"
+
+
+def get_n_basis(atoms: Atoms) -> int:
+    """
+    Get the number of basis functions that will be used for the given input.
+
+    We assume our basis is def2-tzvpd. The number of basis functions is used
+    to estimate the memory requirments of a given job.
+    """
+    nbasis = 0
+    for elt in atoms.get_chemical_symbols():
+        nbasis += BASIS_DICT[elt]
+    return nbasis
+
+
+def get_mem_estimate(atoms: Atoms, vertical=Vertical.Default, mult=1):
+    """
+    Get an estimate of the memory requirement for given input in MB.
+
+    If the estimate is less than 1000MB, we return 1000MB.
+    """
+    nbasis = get_n_basis(atoms)
+    if vertical == Vertical.Default and mult == 1:
+        a = 0.013060654016809259
+        b = -145.62585242047592
+    else:
+        a = 0.016460518374501867
+        b = -320.38502508802776
+    mem_est = max(a * nbasis**1.5 + b, 1000)
+    return mem_est
 
 
 def write_orca_inputs(

--- a/omdata/orca/calc.py
+++ b/omdata/orca/calc.py
@@ -169,6 +169,9 @@ def get_n_basis(atoms: Atoms) -> int:
 
     We assume our basis is def2-tzvpd. The number of basis functions is used
     to estimate the memory requirments of a given job.
+
+    :param atoms: atoms to compute the number of basis functions of
+    :return: number of basis functions as printed by Orca
     """
     nbasis = 0
     for elt in atoms.get_chemical_symbols():
@@ -176,11 +179,17 @@ def get_n_basis(atoms: Atoms) -> int:
     return nbasis
 
 
-def get_mem_estimate(atoms: Atoms, vertical=Vertical.Default, mult=1):
+def get_mem_estimate(atoms: Atoms, vertical=Vertical.Default, mult=1) -> int:
     """
     Get an estimate of the memory requirement for given input in MB.
 
     If the estimate is less than 1000MB, we return 1000MB.
+    
+    :param atoms: atoms to compute the number of basis functions of
+    :param vertical: Which vertical this is for (all metal-organics are
+                     UKS, as are all regular open-shell calcs)
+    :param mult: spin multiplicity of input
+    :return: estimated (upper-bound) to the memory requirement of this Orca job
     """
     nbasis = get_n_basis(atoms)
     if vertical == Vertical.Default and mult == 1:


### PR DESCRIPTION
This function is fit to our particular settings and will not be effective if those settings are changed.