### PR TITLE
Update printing keywords for Orca 6 to include Fock matrix and all orbital energies

### DIFF
--- a/omdata/orca/calc.py
+++ b/omdata/orca/calc.py
@@ -117,7 +117,7 @@ ORCA_SIMPLE_INPUT = [
 ORCA_BLOCKS = [
     "%scf Convergence Tight maxiter 300 end",
     "%elprop Dipole true Quadrupole true end",
-    "%output Print[P_ReducedOrbPopMO_L] 1 Print[P_ReducedOrbPopMO_M] 1 Print[P_BondOrder_L] 1 Print[P_BondOrder_M] 1 end",
+    "%output Print[P_ReducedOrbPopMO_L] 1 Print[P_ReducedOrbPopMO_M] 1 Print[P_BondOrder_L] 1 Print[P_BondOrder_M] 1 Print[P_Fockian] 1 Print[P_OrbEn] 2 end",
     '%basis GTOName "def2-tzvpd.bas" end',
     "%scf THRESH 1e-12 TCUT 1e-13 end",
 ]


### PR DESCRIPTION
Orca 6 fixed the P_Fockian flag to print the final Fock matrix and also changed the number of virtual orbitals printed from all to 10. These changes revert printing all virtual orbitals and adds the Fock matrix.

I checked that these change fix Orca 6 and don't break Orca 5.