### PR TITLE
large polymer afir fixes

### DIFF
--- a/omdata/reactivity_utils.py
+++ b/omdata/reactivity_utils.py
@@ -119,8 +119,9 @@ def run_afir(mol1, mol2, calc, logfile,
              maxforce=4.0,
              is_polymer=False, 
              is_crystal=False,
-             skip_first=False):
-    breaking_cutoff=1.5 # When a bond is breaking, what the distance should be
+             skip_first=False,
+             break_cutoff=1.5):
+    breaking_cutoff=break_cutoff # When a bond is breaking, what the distance should be
     forming_cutoff=1.2 # When a bond is forming, what the distance should be (Angstroms)
     start_force_constant=0.1 # eV/angstrom
     force_increment=force_step # How fast to ramp up the force constant

--- a/reactivity/omer_reactivity_pipeline.py
+++ b/reactivity/omer_reactivity_pipeline.py
@@ -258,12 +258,11 @@ def omer_react_pipeline(chain_dict, output_path, csv_dir, return_ase=False, debu
     with open(logfile, 'a') as file1:
         file1.write(f"Found {len(unique_structures)} unique structures\n")
 
-    if debug:
-        for i, unique_structure in enumerate(unique_structures):
-            unique_structure.set_positions(unique_structure.get_positions(wrap=False))
-            unique_structure.pbc = False
-            unique_structure.cell = None
-            write(os.path.join(output_path, name, f"unique_struc_{i}.xyz"), unique_structure, format="xyz")
+    for i, unique_structure in enumerate(unique_structures):
+        unique_structure.set_positions(unique_structure.get_positions(wrap=False))
+        unique_structure.pbc = False
+        unique_structure.cell = None
+        if debug: write(os.path.join(output_path, name, f"unique_struc_{i}.xyz"), unique_structure, format="xyz")
     
     trimmed_structures = trim_structures(chain, unique_structures, bond_to_break)
 
@@ -285,7 +284,7 @@ def omer_react_pipeline(chain_dict, output_path, csv_dir, return_ase=False, debu
         return trimmed_structures, unique_structures, save_trajectory
 
 def main(all_chains_dir, csv_dir, output_path, n_chunks=1, chunk_idx=0, debug=False):
-    random.seed(17) # CHANGED
+    random.seed(17) # don't have seed change with chunk_idx due to shuffle
     pdb_files = []
     for subdir, _, files in os.walk(all_chains_dir):
         for filename in files:

--- a/reactivity/omer_reactivity_pipeline.py
+++ b/reactivity/omer_reactivity_pipeline.py
@@ -225,7 +225,12 @@ def omer_react_pipeline(chain_dict, output_path, csv_dir, return_ase=False, debu
     chain_path = chain_dict['path']
     chain = chain_dict['chain']
     bond_to_break = chain_dict['bond_to_break']
-    if not is_bonded(chain.ase_atoms, bond_to_break):
+    name = polymer_class + "_" + chain_path.split("/")[-1][:-4]
+
+    os.makedirs(os.path.join(output_path, name), exist_ok=True)
+    logfile = os.path.join(output_path, name, "logfile.txt")
+    
+    if not bond_to_break or not is_bonded(chain.ase_atoms, bond_to_break):
         with open(logfile, 'a') as file1:
             file1.write(f"WARNING: bonded pair being reassigned from {bond_to_break}\n")
         try:
@@ -238,11 +243,6 @@ def omer_react_pipeline(chain_dict, output_path, csv_dir, return_ase=False, debu
     
     _, extra_smiles, polymer_class = get_chain_path_info(chain_path, csv_dir)
     skip_first = True if extra_smiles else False
-
-    name = polymer_class + "_" + chain_path.split("/")[-1][:-4]
-
-    os.makedirs(os.path.join(output_path, name), exist_ok=True)
-    logfile = os.path.join(output_path, name, "logfile.txt")
 
     add_electron = random.choices([-1, 0, 1], weights=[0.1, 0.8, 0.1], k=1)[0]
     charge = chain.ase_atoms.info.get("charge", 0) + add_electron

--- a/reactivity/omer_utils.py
+++ b/reactivity/omer_utils.py
@@ -633,3 +633,9 @@ def surround_chain_with_extra(chain, bond=None, remove=False, max_atoms=250):
         ase_atoms = ase_atoms[kept_indices]
     
     return Chain(ase_atoms, chain.repeat_units, extra_smiles=chain.extra_units)
+
+def is_bonded(ase_atoms, bonded_atoms_list, scale=1.2):
+    i, j = bonded_atoms_list
+    d = ase_atoms.get_distance(i, j, mic=True)
+    cutoff = scale * (covalent_radii[ase_atoms[i].number] + covalent_radii[ase_atoms[j].number])
+    return bool(d < cutoff)

--- a/reactivity/omer_utils.py
+++ b/reactivity/omer_utils.py
@@ -8,7 +8,7 @@ import pandas as pd
 from ase import Atom
 from ase.data import covalent_radii
 
-from rdkit.Chem import EditableMol, BondType, AddHs, MolFromSmarts, Conformer
+from rdkit.Chem import EditableMol, BondType, MolFromSmarts, Conformer
 from rdkit.Geometry import Point3D
 from rdkit.Chem import Atom as RdAtom
 from io_chain import Chain, remove_bond_order, process_repeat_unit
@@ -34,7 +34,7 @@ def get_chain_path_info(pdb_path, csv_dir):
     extra_smiles = []
     if 'Solvent' in basename:
         # no_other_numbers_Solvent_0000_MD_monomer000_no_other_numbers.pdb
-        solv_idx = int(re.search(r'Solvent_(\d+)', basename).group(1)) - 1 # 0-based indexing, assumes one solvent species
+        solv_idx = int(re.search(r'Solvent_(\d+)_MD', basename).group(1)) - 1 # 0-based indexing, assumes one solvent species
         smiles_lists['extra'] = pd.read_csv(os.path.join(csv_dir, 'solvents.csv'))['smiles'].tolist()
         extra_smiles.append(smiles_lists['extra'][solv_idx])
         basename = re.sub(r'Solvent_\d+_', '', basename) # remove solvent number from name
@@ -104,7 +104,7 @@ def trim_structure(chain, structure, bonds_breaking, cutoff, min_atoms=100):
     # get atom mapping for rdkit and ase
     new_atoms = reacted_chain.ase_atoms
 
-    clean_mol = remove_bond_order(AddHs(react_mol))
+    clean_mol = remove_bond_order(react_mol)
     # iterate through chain ends, starting with those farthest from bonds_breaking
     reacted_ends = sort_by_bond_distance(reacted_chain.ase_atoms, bonds_breaking, reacted_chain.ends)[::-1]
     for i in range(len(reacted_ends)):
@@ -119,6 +119,7 @@ def trim_structure(chain, structure, bonds_breaking, cutoff, min_atoms=100):
             continue
         
         while not max_capped and len(new_atoms) > min_atoms:
+            new_atoms = new_atoms.copy()
             matches = list(clean_mol.GetSubstructMatches(mol) for mol in all_mols)       
             match = None
             match_mol = None


### PR DESCRIPTION
* trims down pdbs that are larger than 800 atoms, using `trim_structures`
* fixes solvent parsing when `Solvent_` appears twice in pdb name
* removes superfluous use of `AddHs` which led to errors in `trim_structure` when aromatic rings containing nitrogen were present
* modifies solvent frame trimming to also use `trim_structures` so less timeout exceptions are reached and it's uniform with bulk polymer processing
* better error logging with more useful logfiles
* add breaking cutoff as an argument in `run_afir` to be modular with omer and ocat usage
* assure `bond_to_break` is a valid bonded pair after pre-processing
*  increase ceiling for timeout exceptions
* fix random seed to not change with seed index to assure shuffling is uniform across `chunk_idx`